### PR TITLE
Unescape title and description from HTML source

### DIFF
--- a/tests/unit/test_libs.py
+++ b/tests/unit/test_libs.py
@@ -1,8 +1,10 @@
 # coding: utf-8
+import unittest
 
 from zerqu.libs import renderer
 from zerqu.libs.ratelimit import ratelimit
 from zerqu.libs.utils import is_robot, is_mobile
+from zerqu.libs.webparser import parse_meta
 from zerqu.libs.errors import LimitExceeded
 from ._base import TestCase
 
@@ -72,3 +74,25 @@ class TestRenderer(TestCase):
         s = 'hello\nword\n\nnewline'
         assert '<p>' in renderer.render_text(s)
         assert '<br>' in renderer.render_text(s)
+
+
+class TestParser(unittest.TestCase):
+    def test_parse_meta(self):
+        link = u'http://fabric-chs.readthedocs.org/zh_CN/chs/'
+        rsp = u'''
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>欢迎访问 Fabric 中文文档 &mdash; Fabric  文档</title>
+<link rel="top" title="Fabric  文档" href="#" />
+<link rel="next" title="概览 &amp; 教程" href="tutorial.html" />
+</head>
+<body role="document">
+</body>
+</html>
+'''
+        meta = parse_meta(rsp, link)
+        assert u'—' in meta[u'title']
+        assert u'&mdash;' not in meta[u'title']

--- a/zerqu/libs/webparser.py
+++ b/zerqu/libs/webparser.py
@@ -9,6 +9,7 @@
 import re
 import requests
 from werkzeug.urls import url_parse, url_join
+from werkzeug.utils import unescape
 
 __version__ = '0.1'
 __author__ = 'Hsiaoming Yang <me@lepture.com>'
@@ -78,6 +79,10 @@ def parse_meta(content, link=None):
         rv[u'image'] = url_join(link, rv[u'image'])
 
     rv.update(parse_embed(pairs))
+
+    for key in [u'title', u'description']:
+        if rv.get(key):
+            rv[key] = unescape(rv[key])
     return rv
 
 


### PR DESCRIPTION
Escaped HTML would now unescaped to what it originally is.

For example, ``<title>Fabric &mdash Fabric</title>`` would now get ``Fabric — Fabric`` instead of ``Fabric &mdash; Fabric``