### PR TITLE
docker support for Zerqu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7
+
+RUN mkdir /code
+WORKDIR /code
+ADD deps/ /code/deps
+
+RUN pip install -r deps/requirements.txt
+RUN pip install -r deps/develop.txt
+RUN pip install -r deps/extra.txt
+RUN pip install -r deps/tests.txt
+
+ADD . /code
+

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ Zerqu is a forum library that provides APIs to create topics, comments and etc.
 Development
 -----------
 
+Using Vagrant
+~~~~~~~~~~~~~
+
 Prerequests:
 
 1. VirtualBox
@@ -34,3 +37,23 @@ Run app server in vagrant ``/vagrant`` directory::
     $ make run
 
 Visit: `http://192.168.30.10:5000/`
+
+The docker way
+~~~~~~~~~~~~~~
+
+You can also run zerqu in docker.
+
+Prerequests:
+
+1. docker
+2. docker-compose
+
+Build docker containers::
+
+    $ docker-compose up
+
+Initiate database schema::
+
+    $ docker-compose run web bash -c "ZERQU_CONF=/code/local_config.py alembic upgrade head"
+
+Visit: `http://localhost:5000`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+db:
+  image: postgres:9.5
+  environment:
+    - POSTGRES_PASSWORD=secret
+    - POSTGRES_DB=development
+    - PGDATA=/data
+  volumes:
+    - ./data/:/code
+
+redis:
+  image: redis:3.2
+
+web:
+  links:
+    - db
+    - redis
+  build: .
+  volumes:
+    - .:/code
+  ports:
+          - "5000:5000"
+  command: python manage.py runserver -h 0.0.0.0
+

--- a/local_config.py
+++ b/local_config.py
@@ -1,3 +1,26 @@
+import os
+
+
 SECRET_KEY = 'secret'
-SQLALCHEMY_DATABASE_URI = 'postgresql://postgres@localhost/development'
+
+if os.path.isfile('/.dockerenv'):
+    is_docker = True
+else:
+    is_docker = False
+
+if is_docker:
+    DB_CONN = 'postgres:secret@db'
+else:
+    DB_CONN = 'postgres@localhost'
+
+SQLALCHEMY_DATABASE_URI = 'postgresql://{conn}/development'.format(conn=DB_CONN)
 SQLALCHEMY_NATIVE_UNICODE = False
+
+if is_docker:
+    REDIS_HOST = 'redis'
+else:
+    REDIS_HOST = 'localhost'
+ZERQU_REDIS_URI = 'redis://{}:6379/0'.format(REDIS_HOST)
+ZERQU_CACHE_REDIS_HOST = REDIS_HOST
+
+DEBUG = True


### PR DESCRIPTION
You can now start a docker container in project root directory with command ``docker-compose up``. A Zerqu service would be served at ``localhost:5000`` when container building is finished.

As first time to start it, you need to init the database schema with running ``docker-compose run web bash -c "ZERQU_CONF=/code/local_config.py alembic upgrade head"``.