### PR TITLE
Replace `docker-compose run` by `docker-compose exec`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ babel-compile:
 
 
 database:
-	@docker-compose run web bash -c "ZERQU_CONF=/code/local_config.py alembic upgrade head"
+	@docker-compose exec web alembic upgrade head

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - .:/code
     ports:
       - "5000:5000"
+    environment:
+      - ZERQU_CONF=/code/local_config.py
     command: python manage.py runserver -h 0.0.0.0
     depends_on:
       - postgres


### PR DESCRIPTION
`docker-compose run` will create a container and execute cmd, can use `docker-compose run --rm` remove container after run. 
But `docker-compose exec` command runs a new command in a running container.
