### PR TITLE
docs: Fix simple typo, sepcified -> specified

### DIFF
--- a/zerqu/app.py
+++ b/zerqu/app.py
@@ -41,7 +41,7 @@ def create_app(config=None):
     if 'ZERQU_CONF' in os.environ:
         app.config.from_envvar('ZERQU_CONF')
 
-    #: load app sepcified configuration
+    #: load app specified configuration
     if config is not None:
         if isinstance(config, dict):
             app.config.update(config)


### PR DESCRIPTION
There is a small typo in zerqu/app.py.

Should read `specified` rather than `sepcified`.

